### PR TITLE
Add Double letters handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ttastromech"
-version = "0.6.0"
+version = "0.6.1"
 description = "python library transform text strings into Astromech (like R2D2) sounds"
 authors = ["walchko <walchko@users.noreply.github.com>"]
 readme = "readme.rst"
@@ -8,7 +8,7 @@ license = "MIT"
 homepage = "https://pypi.org/project/ttastromech/"
 repository = 'http://github.com/MomsFriendlyRobotCompany/ttastromech'
 # documentation = "http://..."
-keywords = ['r2d2', 'tts', 'star wars', 'driod', 'astromech']
+keywords = ['r2d2', 'tts', 'star wars', 'droid', 'astromech']
 classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,0 @@
-
-
-def test_dummy():
-	assert True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,11 @@
+import pytest
+from ttastromech import TTAstromech
+
+def test_dummy():
+    assert True
+
+def test_lowercase_letters_only():
+   r2 = TTAstromech()
+   r2.speak("hello world")
+   assert True
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,3 +9,8 @@ def test_lowercase_letters_only():
    r2.speak("hello world")
    assert True
 
+def test_double_letters():
+   r2 = TTAstromech()
+   r2.speak("g a giggle")
+   r2.speak("u o u o uu oo")
+   assert True

--- a/ttastromech/ttastromech.py
+++ b/ttastromech/ttastromech.py
@@ -26,6 +26,7 @@ class AudioPlayer:
 
         elif plat == 'Linux':
             for play in ['aplay', 'play']:
+                # TODO: research/consider paplay , ffplay , and mplayer as well?
                 # ret = os.system('which {}'.format(play))
                 ret = Popen('which {}'.format(play), shell=True).wait()
                 if ret == 0:
@@ -43,6 +44,8 @@ class AudioPlayer:
                     self.audio_player = cmd
                     break
 
+                #TODO: plat == 'Windows':
+                #use start, but only after cd to file dir
         else:
             raise Exception('OS is unsupported')
 
@@ -85,12 +88,12 @@ class TTAstromech:
         """Pull the audio data off of disk corresponding to the syllable."""
         audio_data = b""
 
-        for letter in syllable:
-            letter = letter.lower()  # need this?
-            if not letter.isalpha():
-                continue
+        if not syllable.isalnum():
+            print("skipping unsupported syllable/letter" + syllable)
+        else:
+            syllable = syllable.lower()  # need this?
             try:
-                wav_file = wave.open(self.root.format(letter), "rb")
+                wav_file = wave.open(self.root.format(syllable), "rb")
                 audio_data += wav_file.readframes(wav_file.getnframes())
                 wav_file.close()
             except Exception as fs_ex:
@@ -114,10 +117,12 @@ class TTAstromech:
         and invoke the audio render."""
         data = b""
         previous_ltr= b""
+        double_letters = [letter[0] for letter in self.syllabary if '1' in letter]
         for ltr in phrase:
             if ltr.isalpha():
-                if ltr == previous_ltr and ltr in ['c','g','o','u','s']:
+                if ltr == previous_ltr and ltr in double_letters:
                     data += self.syllabary[ltr+"1"]
+                    #print("Double-letter syllable invoked")
                 else:
                     data += self.syllabary[ltr]
                 previous_ltr = ltr


### PR DESCRIPTION
I noticed the presence of c1.wav, g1.wav, o1.wav, u1.wav but I couldn't see those getting handled in any way in the main class. It struck me that these all are letters that appear doubled (granted u being a rare case, and consipicuosly missing s and t and d, though those could easily be added in a later pull request) in English vocabulary. This just imports those files into the syllabary and then when a speak request notices a double letter sequence, it invokes the alternate wav for the second instance. 

This pull request is stacked on top of prior standardization pull request. I'm not sure about the etiquette for that scenario, but I would say that other pull should be handled first.